### PR TITLE
Rayon support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,82 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "blend-srgb"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a187f5213b0a15f4344b1850bf1bd1f5cbe98eaf61d9914406723a9a2e6426"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "once_cell",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "iai"
@@ -45,6 +111,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+
+[[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "stackblur"
 version = "0.1.0"
 source = "git+https://github.com/LoganDark/stackblur?branch=larger-radius#3c8ae04e020e411cbbdbbb9e43e11c02a54d8e3e"
@@ -60,5 +187,13 @@ dependencies = [
  "iai",
  "imgref",
  "imgref-iter",
+ "rayon",
  "stackblur",
+ "unique",
 ]
+
+[[package]]
+name = "unique"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d360722e1f3884f5b14d332185f02ff111f771f0c76a313268fe6af1409aba96"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,16 @@ exclude = ['.idea']
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+blend-srgb = ['dep:blend-srgb']
+rayon = ['dep:rayon', 'dep:unique']
+
 [dependencies]
 imgref = '^1.9.2'
 imgref-iter = '~0.3.0'
 blend-srgb = { version = '~0.1.1', optional = true }
+rayon = { version = '^1.5.3', optional = true }
+unique = { version = '~0.9.1', optional = true }
 
 [dev-dependencies]
 stackblur = { git = 'https://github.com/LoganDark/stackblur', branch = 'larger-radius' }

--- a/benches/iai.rs
+++ b/benches/iai.rs
@@ -18,6 +18,8 @@ fn blur_srgb_16() { stackblur_iter::blur_srgb(&mut img(), 16) }
 fn blur_srgb_128() { stackblur_iter::blur_srgb(&mut img(), 128) }
 fn blur_srgb_1024() { stackblur_iter::blur_srgb(&mut img(), 1024) }
 
+// parallel versions are non-deterministic
+
 iai::main!(
 	blur_argb_16,
 	blur_argb_128,

--- a/src/test.rs
+++ b/src/test.rs
@@ -57,6 +57,51 @@ fn blur_srgb_1024(bencher: &mut Bencher) {
 
 #[bench]
 #[inline(never)]
+fn par_blur_argb_16(bencher: &mut Bencher) {
+	let mut buf = ImgVec::new(vec![0; WIDTH * HEIGHT], WIDTH, HEIGHT);
+	bencher.iter(|| crate::par_blur_argb(&mut buf.as_mut(), 16));
+}
+
+#[bench]
+#[inline(never)]
+fn par_blur_argb_128(bencher: &mut Bencher) {
+	let mut buf = ImgVec::new(vec![0; WIDTH * HEIGHT], WIDTH, HEIGHT);
+	bencher.iter(|| crate::par_blur_argb(&mut buf.as_mut(), 128));
+}
+
+#[bench]
+#[inline(never)]
+fn par_blur_argb_1024(bencher: &mut Bencher) {
+	let mut buf = ImgVec::new(vec![0; WIDTH * HEIGHT], WIDTH, HEIGHT);
+	bencher.iter(|| crate::par_blur_argb(&mut buf.as_mut(), 1024));
+}
+
+#[cfg(feature = "blend-srgb")]
+#[bench]
+#[inline(never)]
+fn par_blur_srgb_16(bencher: &mut Bencher) {
+	let mut buf = ImgVec::new(vec![0; WIDTH * HEIGHT], WIDTH, HEIGHT);
+	bencher.iter(|| crate::par_blur_srgb(&mut buf.as_mut(), 16));
+}
+
+#[cfg(feature = "blend-srgb")]
+#[bench]
+#[inline(never)]
+fn par_blur_srgb_128(bencher: &mut Bencher) {
+	let mut buf = ImgVec::new(vec![0; WIDTH * HEIGHT], WIDTH, HEIGHT);
+	bencher.iter(|| crate::par_blur_srgb(&mut buf.as_mut(), 128));
+}
+
+#[cfg(feature = "blend-srgb")]
+#[bench]
+#[inline(never)]
+fn par_blur_srgb_1024(bencher: &mut Bencher) {
+	let mut buf = ImgVec::new(vec![0; WIDTH * HEIGHT], WIDTH, HEIGHT);
+	bencher.iter(|| crate::par_blur_srgb(&mut buf.as_mut(), 1024));
+}
+
+#[bench]
+#[inline(never)]
 fn stackblur_16_horiz(bencher: &mut Bencher) {
 	let mut buf = vec![0; WIDTH * HEIGHT];
 	bencher.iter(|| stackblur::blur_horiz(&mut buf, WIDTH_NONZERO, unsafe { NonZeroU32::new_unchecked(16) }));


### PR DESCRIPTION
I made changes in `imgref-iter` to make this possible.

Behold:

```
stackblur_1024       ... bench:  18,514,600 ns/iter (+/- 3,095,887)
stackblur_128        ... bench:  11,743,780 ns/iter (+/- 2,533,038)
stackblur_16         ... bench:  11,109,190 ns/iter (+/- 1,912,941)
blur_srgb_1024       ... bench:  17,162,590 ns/iter (+/- 3,337,943)
blur_srgb_128        ... bench:  14,260,590 ns/iter (+/- 2,214,481)
blur_srgb_16         ... bench:  13,107,140 ns/iter (+/- 2,408,900)
par_blur_srgb_1024   ... bench:   4,309,255 ns/iter (+/- 352,918)
par_blur_srgb_128    ... bench:   3,979,880 ns/iter (+/- 305,431)
par_blur_srgb_16     ... bench:   4,063,585 ns/iter (+/- 310,803)
```

Fixes #3